### PR TITLE
Added improved DI support

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -61,6 +61,8 @@ private object AppDependencies {
       override lazy val test = Seq(
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "org.scalatest" %% "scalatest" % "2.2.4" % scope,
+        "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test",
+        "org.mockito" % "mockito-all" % "1.9.5" % scope,
         "org.pegdown" % "pegdown" % "1.5.0" % scope
       )
     }.test

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
 import com.codahale.metrics.{MetricFilter, SharedMetricRegistries}
 import play.api.{Application, Configuration, GlobalSettings, Logger}
 
+@deprecated("Use DI", "-")
 trait GraphiteConfig extends GlobalSettings {
 
   def microserviceMetricsConfig(implicit app: Application) : Option[Configuration]

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsImpl.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsImpl.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.graphite
+
+import javax.inject.{Inject, Singleton}
+
+import com.codahale.metrics
+import com.codahale.metrics.MetricRegistry
+import com.kenshoo.play.metrics.MetricsImpl
+import play.api.Configuration
+import play.api.inject.ApplicationLifecycle
+
+/**
+  * Class prevents the default behaviour of removing shared registries when the application stops
+  * @param lifecycle
+  * @param configuration
+  */
+@deprecated("This class prevents correct application shutdown processes and should be avoided, use `MetricsImpl` instead", "-")
+@Singleton
+class GraphiteMetricsImpl @Inject() (
+                                      lifecycle: ApplicationLifecycle,
+                                      configuration: Configuration
+                                    ) extends MetricsImpl(lifecycle, configuration) {
+  override def onStop() = {}
+}

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteProvider.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteProvider.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.graphite
+
+import java.net.InetSocketAddress
+import javax.inject.{Inject, Provider}
+
+import com.codahale.metrics.graphite.Graphite
+import com.typesafe.config.Config
+import play.api.Configuration
+
+case class GraphiteProviderConfig(
+                                 host: String,
+                                 port: Int
+                                 )
+
+object GraphiteProviderConfig {
+
+  def fromConfig(config: Configuration): GraphiteProviderConfig = {
+
+    val graphite: Config  = config.underlying.getConfig("metrics.graphite")
+    val host: String      = graphite.getString("host")
+    val port: Int         = graphite.getInt("port")
+
+    GraphiteProviderConfig(host, port)
+  }
+}
+
+class GraphiteProvider @Inject() (
+                                   config: GraphiteProviderConfig
+                                 ) extends Provider[Graphite] {
+
+  override def get(): Graphite = {
+    new Graphite(new InetSocketAddress(config.host, config.port))
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteReporterProvider.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteReporterProvider.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.graphite
+
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Provider}
+
+import com.codahale.metrics.MetricFilter
+import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
+import com.kenshoo.play.metrics.Metrics
+import com.typesafe.config.ConfigException
+import play.api.Configuration
+
+case class GraphiteReporterProviderConfig(
+                                         prefix: String,
+                                         rates: Option[TimeUnit],
+                                         durations: Option[TimeUnit]
+                                         )
+
+object GraphiteReporterProviderConfig {
+
+  def fromConfig(config: Configuration): GraphiteReporterProviderConfig = {
+
+    val appName: Option[String]       = config.getString("appName")
+    val rates: Option[TimeUnit]       = config.getString("metrics.graphite.rates").map(TimeUnit.valueOf)
+    val durations: Option[TimeUnit]   = config.getString("metrics.graphite.durations").map(TimeUnit.valueOf)
+
+    val prefix: String = config.getString("metrics.graphite.prefix")
+      .orElse(appName.map(name => s"tax.$name"))
+      .getOrElse(throw new ConfigException.Generic("`metrics.graphite.prefix` in config or `appName` as parameter required"))
+
+    GraphiteReporterProviderConfig(prefix, rates, durations)
+  }
+}
+
+class GraphiteReporterProvider @Inject() (
+                                         config: GraphiteReporterProviderConfig,
+                                         metrics: Metrics,
+                                         graphite: Graphite,
+                                         filter: MetricFilter
+                                         ) extends Provider[GraphiteReporter] {
+
+  override def get(): GraphiteReporter =
+    GraphiteReporter
+        .forRegistry(metrics.defaultRegistry)
+        .prefixedWith(s"${config.prefix}.${java.net.InetAddress.getLocalHost.getHostName}")
+        .convertDurationsTo(config.durations.getOrElse(TimeUnit.SECONDS))
+        .convertRatesTo(config.rates.getOrElse(TimeUnit.MILLISECONDS))
+        .filter(filter)
+        .build(graphite)
+}

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteReporting.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteReporting.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.graphite
+
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+
+import com.codahale.metrics.graphite.GraphiteReporter
+import play.api.inject.ApplicationLifecycle
+import play.api.{Configuration, Logger}
+
+import scala.concurrent.Future
+
+trait GraphiteReporting
+
+class DisabledGraphiteReporting @Inject() extends GraphiteReporting {
+
+  Logger.info("Graphite metrics disabled")
+}
+
+@Singleton
+class EnabledGraphiteReporting @Inject() (
+                                  config: Configuration,
+                                  reporter: GraphiteReporter,
+                                  lifecycle: ApplicationLifecycle
+                                ) extends GraphiteReporting {
+
+  protected def interval: Long = config.getLong("metrics.graphite.interval").getOrElse(10L)
+
+  Logger.info("Graphite metrics enabled, starting the reporter")
+
+  // start graphite reporter
+  reporter.start(interval, TimeUnit.SECONDS)
+
+  // stop graphite reporter on application shut down
+  lifecycle.addStopHook {
+    () =>
+      Future.successful(reporter.stop())
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/play/graphite/MicroserviceMetrics.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/MicroserviceMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package uk.gov.hmrc.play.graphite
 import com.kenshoo.play.metrics.Metrics
 import play.api.Play
 
+@deprecated("Use DI", "-")
 trait MicroserviceMetrics {
-  val metrics = Play.current.injector.instanceOf[Metrics]
+  val metrics: Metrics = Play.current.injector.instanceOf[Metrics]
 }

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModuleSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModuleSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.graphite
+
+import com.codahale.metrics.{MetricFilter, SharedMetricRegistries}
+import com.kenshoo.play.metrics._
+import org.scalatest._
+import play.api.inject.guice.GuiceApplicationBuilder
+
+class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAndAfterEach {
+
+  def app: GuiceApplicationBuilder =
+    new GuiceApplicationBuilder()
+      .bindings(new GraphiteMetricsModule)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    SharedMetricRegistries.clear()
+  }
+
+  ".bindings" when {
+
+    "`metrics.graphite.legacy` is true" must {
+
+      def app: GuiceApplicationBuilder =
+        new GuiceApplicationBuilder()
+          .bindings(new GraphiteMetricsModule)
+
+      def defaultBindings(builder: => GuiceApplicationBuilder): Unit = {
+
+        // NOTE: Even though this is being done in the `beforeEach` it doesn't
+        // seem to help with mixed in behaviours, so it must be here too.
+        SharedMetricRegistries.clear()
+
+        val injector = builder.build().injector
+
+        "have default bindings" in {
+
+          injector.instanceOf[MetricsFilter] mustBe a[MetricsFilterImpl]
+          injector.instanceOf[Metrics] mustBe a[GraphiteMetricsImpl]
+        }
+      }
+
+      "providing no configuration" must {
+        behave like defaultBindings(app)
+      }
+
+      "setting `metrics.enabled` to true" must {
+        behave like defaultBindings(
+          app.configure("metrics.enabled" -> "true")
+        )
+      }
+
+      "setting `metrics.enabled` to false" must {
+
+        val injector = app.configure(
+          "metrics.enabled" -> "false"
+        ).build().injector
+
+        injector.instanceOf[MetricsFilter] mustBe a[DisabledMetricsFilter]
+        injector.instanceOf[Metrics] mustBe a[DisabledMetrics]
+      }
+    }
+
+    "`metrics.graphite.legacy` is false" must {
+
+      def app: GuiceApplicationBuilder =
+        new GuiceApplicationBuilder()
+          .bindings(new GraphiteMetricsModule)
+          .configure(
+            "metrics.graphite.legacy" -> "false",
+            "metrics.graphite.host" -> "test",
+            "metrics.graphite.port" -> "9999",
+            "appName" -> "test"
+          )
+
+      def defaultBindings(builder: => GuiceApplicationBuilder): Unit = {
+
+        // NOTE: Even though this is being done in the `beforeEach` it doesn't
+        // seem to help with mixed in behaviours, so it must be here too.
+        SharedMetricRegistries.clear()
+
+        val injector = builder.build().injector
+
+        "have default bindings" in {
+
+          injector.instanceOf[MetricFilter] mustEqual MetricFilter.ALL
+          injector.instanceOf[MetricsFilter] mustBe a[MetricsFilterImpl]
+          injector.instanceOf[Metrics] mustBe a[MetricsImpl]
+          injector.instanceOf[GraphiteReporting] mustBe a[EnabledGraphiteReporting]
+        }
+      }
+
+      "providing no configuration" must {
+        behave like defaultBindings(app)
+      }
+
+      "setting `metrics.enabled` to true" must {
+        behave like defaultBindings(
+          app.configure("metrics.enabled" -> "true")
+        )
+      }
+
+      "setting `metrics.enabled` to false" in {
+
+        val injector = app.configure(
+          "metrics.enabled" -> "false"
+        ).build().injector
+
+        injector.instanceOf[MetricFilter] mustEqual MetricFilter.ALL
+        injector.instanceOf[MetricsFilter] mustBe a[DisabledMetricsFilter]
+        injector.instanceOf[Metrics] mustBe a[DisabledMetrics]
+        injector.instanceOf[GraphiteReporting] mustBe a[DisabledGraphiteReporting]
+      }
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteProviderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteProviderSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.graphite
+
+import com.typesafe.config.ConfigException
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.Configuration
+import play.api.inject.Injector
+import play.api.inject.guice.GuiceApplicationBuilder
+
+class GraphiteProviderSpec extends WordSpec with MustMatchers {
+
+  "GraphiteProviderConfigSpec.fromConfig" must {
+
+    val configuration: Map[String, String] = Map(
+      "metrics.graphite.host" -> "localhost",
+      "metrics.graphite.port" -> "9999"
+    )
+
+    "return a valid `GraphiteProviderConfig`" in {
+
+      val injector: Injector = new GuiceApplicationBuilder()
+        .configure(configuration)
+        .build()
+        .injector
+
+      val config: GraphiteProviderConfig =
+        GraphiteProviderConfig.fromConfig(injector.instanceOf[Configuration])
+
+      config.host mustEqual "localhost"
+      config.port mustEqual 9999
+    }
+
+    configuration.keys.foreach {
+      key =>
+        s"throw a configuration exception when config key: $key, is missing" in {
+
+          val injector = new GuiceApplicationBuilder()
+            .configure(configuration - key)
+            .build()
+            .injector
+
+          intercept[ConfigException.Missing] {
+            GraphiteProviderConfig.fromConfig(injector.instanceOf[Configuration])
+          }
+        }
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteReportingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteReportingSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.graphite
+
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.graphite.GraphiteReporter
+import org.mockito.Matchers._
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers
+
+class GraphiteReportingSpec extends WordSpec with MustMatchers with MockitoSugar with BeforeAndAfterEach {
+
+  val graphite: GraphiteReporter = mock[GraphiteReporter]
+
+  def app: GuiceApplicationBuilder = {
+
+    import play.api.inject._
+
+    new GuiceApplicationBuilder()
+      .bindings(
+        bind[GraphiteReporter].toInstance(graphite),
+        bind[GraphiteReporting].to[EnabledGraphiteReporting].eagerly
+      )
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    Mockito.reset(graphite)
+  }
+
+  "GraphiteReporting" must {
+
+    "start the reporter when metrics are enabled with default interval" in {
+
+      Helpers.running(app.build()) {
+        verify(graphite).start(10L, TimeUnit.SECONDS)
+      }
+      verify(graphite).stop()
+    }
+
+    "start the reporter when metrics are enabled with custom interval" in {
+
+      Helpers.running(app.configure("metrics.graphite.interval" -> "11").build()) {
+        verify(graphite).start(11L, TimeUnit.SECONDS)
+      }
+      verify(graphite).stop()
+    }
+
+    "not start the reporter when metrics are disabled" ignore {
+
+      Helpers.running(app.configure("metrics.enabled" -> "false").build()) {
+        verify(graphite, never()).start(any(), any())
+      }
+      verify(graphite, never()).stop()
+    }
+
+    "not start the reporter when graphite is disabled" ignore {
+
+      Helpers.running(app.configure("metrics.graphite.enabled" -> "false").build()) {
+        verify(graphite, never()).start(any(), any())
+      }
+      verify(graphite, never()).stop()
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteReportingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteReportingSpec.scala
@@ -64,21 +64,5 @@ class GraphiteReportingSpec extends WordSpec with MustMatchers with MockitoSugar
       }
       verify(graphite).stop()
     }
-
-    "not start the reporter when metrics are disabled" ignore {
-
-      Helpers.running(app.configure("metrics.enabled" -> "false").build()) {
-        verify(graphite, never()).start(any(), any())
-      }
-      verify(graphite, never()).stop()
-    }
-
-    "not start the reporter when graphite is disabled" ignore {
-
-      Helpers.running(app.configure("metrics.graphite.enabled" -> "false").build()) {
-        verify(graphite, never()).start(any(), any())
-      }
-      verify(graphite, never()).stop()
-    }
   }
 }


### PR DESCRIPTION
- Deprecated `GraphiteConfig` trait, replaced by a DI-able `GraphiteReporting` instance.
- Deprecated `MicroserviceMetrics` trait, replaced by Di-ing a `Metrics` instance directly.
- Added a configuration flag `metrics.graphite.legacy` which defaults to `true` to enable backwards compatibility.
- Added tests for all new functionality.