### PR TITLE
PLATOPS-1058 Support for property names using existing naming conventions.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModule.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModule.scala
@@ -26,8 +26,8 @@ class GraphiteMetricsModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
 
-    val metricsConfiguration = configuration.getConfig(s"${environment.mode.toString}.metrics")
-      .orElse(configuration.getConfig("metrics")).getOrElse(Configuration())
+    val metricsConfiguration = configuration.getConfig(s"${environment.mode.toString}.microservice.metrics")
+      .orElse(configuration.getConfig("microservice.metrics")).getOrElse(Configuration())
 
     if (metricsConfiguration.getBoolean("graphite.legacy").getOrElse(true)) {
       legacy(environment, metricsConfiguration)

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteProvider.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteProvider.scala
@@ -30,9 +30,9 @@ case class GraphiteProviderConfig(
 
 object GraphiteProviderConfig {
 
-  def fromConfig(config: Configuration): GraphiteProviderConfig = {
+  def fromConfig(metricsConfiguration: Configuration): GraphiteProviderConfig = {
 
-    val graphite: Config  = config.underlying.getConfig("metrics.graphite")
+    val graphite: Config  = metricsConfiguration.underlying.getConfig("graphite")
     val host: String      = graphite.getString("host")
     val port: Int         = graphite.getInt("port")
 

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteReporterProvider.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteReporterProvider.scala
@@ -33,13 +33,13 @@ case class GraphiteReporterProviderConfig(
 
 object GraphiteReporterProviderConfig {
 
-  def fromConfig(config: Configuration): GraphiteReporterProviderConfig = {
+  def fromConfig(config: Configuration, metricsConfig : Configuration): GraphiteReporterProviderConfig = {
 
     val appName: Option[String]       = config.getString("appName")
-    val rates: Option[TimeUnit]       = config.getString("metrics.graphite.rates").map(TimeUnit.valueOf)
-    val durations: Option[TimeUnit]   = config.getString("metrics.graphite.durations").map(TimeUnit.valueOf)
+    val rates: Option[TimeUnit]       = metricsConfig.getString("graphite.rates").map(TimeUnit.valueOf)
+    val durations: Option[TimeUnit]   = metricsConfig.getString("graphite.durations").map(TimeUnit.valueOf)
 
-    val prefix: String = config.getString("metrics.graphite.prefix")
+    val prefix: String = metricsConfig.getString("graphite.prefix")
       .orElse(appName.map(name => s"tax.$name"))
       .getOrElse(throw new ConfigException.Generic("`metrics.graphite.prefix` in config or `appName` as parameter required"))
 

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModuleSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModuleSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.play.graphite
 import com.codahale.metrics.{MetricFilter, SharedMetricRegistries}
 import com.kenshoo.play.metrics._
 import org.scalatest._
+import play.api.Configuration
 import play.api.inject.guice.GuiceApplicationBuilder
 
 class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAndAfterEach {
@@ -34,93 +35,135 @@ class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAn
 
   ".bindings" when {
 
-    "`metrics.graphite.legacy` is true" must {
+    "`$env.metrics.graphite.legacy` is true" when {
 
-      def app: GuiceApplicationBuilder =
-        new GuiceApplicationBuilder()
-          .bindings(new GraphiteMetricsModule)
-
-      def defaultBindings(builder: => GuiceApplicationBuilder): Unit = {
-
-        // NOTE: Even though this is being done in the `beforeEach` it doesn't
-        // seem to help with mixed in behaviours, so it must be here too.
-        SharedMetricRegistries.clear()
-
-        val injector = builder.build().injector
-
-        "have default bindings" in {
-
-          injector.instanceOf[MetricsFilter] mustBe a[MetricsFilterImpl]
-          injector.instanceOf[Metrics] mustBe a[GraphiteMetricsImpl]
-        }
+      "`$env.metrics.enabled` is not set" must {
+        behave like haveLegacyBindings(Configuration())
       }
 
-      "providing no configuration" must {
-        behave like defaultBindings(app)
+      "`metrics.enabled` is set to true" must {
+        behave like haveLegacyBindings(Configuration("Test.metrics.enabled" -> "true"))
       }
 
-      "setting `metrics.enabled` to true" must {
-        behave like defaultBindings(
-          app.configure("metrics.enabled" -> "true")
-        )
-      }
-
-      "setting `metrics.enabled` to false" must {
+      "`metrics.enabled` is set to false" must {
 
         val injector = app.configure(
-          "metrics.enabled" -> "false"
+          "Test.metrics.enabled" -> "false"
         ).build().injector
 
-        injector.instanceOf[MetricsFilter] mustBe a[DisabledMetricsFilter]
-        injector.instanceOf[Metrics] mustBe a[DisabledMetrics]
+        "create legacy bindings with reporting disabled" in {
+          injector.instanceOf[MetricsFilter] mustBe a[DisabledMetricsFilter]
+          injector.instanceOf[Metrics] mustBe a[DisabledMetrics]
+        }
       }
     }
 
-    "`metrics.graphite.legacy` is false" must {
+    "`$env.metrics.graphite.legacy` is false" when {
 
-      def app: GuiceApplicationBuilder =
-        new GuiceApplicationBuilder()
-          .bindings(new GraphiteMetricsModule)
-          .configure(
-            "metrics.graphite.legacy" -> "false",
-            "metrics.graphite.host" -> "test",
-            "metrics.graphite.port" -> "9999",
-            "appName" -> "test"
-          )
+      val graphiteConfiguration = Configuration(
+        "Test.metrics.graphite.legacy" -> "false",
+        "Test.metrics.graphite.host" -> "test",
+        "Test.metrics.graphite.port" -> "9999",
+        "appName" -> "test"
+      )
 
-      def defaultBindings(builder: => GuiceApplicationBuilder): Unit = {
-
-        // NOTE: Even though this is being done in the `beforeEach` it doesn't
-        // seem to help with mixed in behaviours, so it must be here too.
-        SharedMetricRegistries.clear()
-
-        val injector = builder.build().injector
-
-        "have default bindings" in {
-
-          injector.instanceOf[MetricFilter] mustEqual MetricFilter.ALL
-          injector.instanceOf[MetricsFilter] mustBe a[MetricsFilterImpl]
-          injector.instanceOf[Metrics] mustBe a[MetricsImpl]
-          injector.instanceOf[GraphiteReporting] mustBe a[EnabledGraphiteReporting]
-        }
+      "`$env.metrics.enabled` is not set" must {
+        behave like haveDefaultBindings(graphiteConfiguration)
       }
 
-      "providing no configuration" must {
-        behave like defaultBindings(app)
+      "`$env.metrics.enabled` is set to true" must {
+        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("Test.metrics.enabled" -> "true"))
       }
 
-      "setting `metrics.enabled` to true" must {
-        behave like defaultBindings(
-          app.configure("metrics.enabled" -> "true")
-        )
+      "`$env.metrics.enabled` is set to false" must {
+        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("Test.metrics.enabled" -> "false"))
       }
 
-      "setting `metrics.enabled` to false" in {
+    }
 
-        val injector = app.configure(
-          "metrics.enabled" -> "false"
-        ).build().injector
+    " environment specific configuration is not set but default configuration is provided " when {
 
+      val graphiteConfiguration = Configuration(
+        "metrics.graphite.legacy" -> "false",
+        "metrics.graphite.host" -> "test",
+        "metrics.graphite.port" -> "9999",
+        "appName" -> "test"
+      )
+
+      "`metrics.enabled` is not set" must {
+        behave like haveDefaultBindings(graphiteConfiguration)
+      }
+
+      "`metrics.enabled` is set to true" must {
+        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("metrics.enabled" -> "true"))
+      }
+
+      "`metrics.enabled` is set to false" must {
+        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("metrics.enabled" -> "false"))
+      }
+
+    }
+
+    " both environment configuration and default configuration specified" when {
+      val graphiteConfiguration = Configuration(
+        "Test.metrics.graphite.legacy" -> "false",
+        "metrics.graphite.legacy" -> "true",
+        "Test.metrics.graphite.host" -> "test",
+        "Test.metrics.graphite.port" -> "9999",
+        "appName" -> "test"
+      )
+
+      "`metrics.enabled` is not set" must {
+        behave like haveDefaultBindings(graphiteConfiguration)
+      }
+
+      "`metrics.enabled` is set to true" must {
+        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("Test.metrics.enabled" -> "true"))
+      }
+
+      "`metrics.enabled` is set to false" must {
+        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("Test.metrics.enabled" -> "false"))
+      }
+    }
+
+    def buildInjectorWithMetrics(config : Configuration) = {
+
+      // NOTE: Even though this is being done in the `beforeEach` it doesn't
+      // seem to help with mixed in behaviours, so it must be here too.
+      SharedMetricRegistries.clear()
+
+      new GuiceApplicationBuilder()
+        .bindings(new GraphiteMetricsModule)
+        .configure(config)
+        .build()
+        .injector
+    }
+
+    def haveLegacyBindings(config : Configuration): Unit = {
+      val injector = buildInjectorWithMetrics(config)
+
+      "create legacy bindings" in {
+        injector.instanceOf[MetricsFilter] mustBe a[MetricsFilterImpl]
+        injector.instanceOf[Metrics] mustBe a[GraphiteMetricsImpl]
+      }
+    }
+
+    def haveDefaultBindings(configuration : Configuration): Unit = {
+      val injector = buildInjectorWithMetrics(configuration)
+
+      "create new bindings" in {
+
+        injector.instanceOf[MetricFilter] mustEqual MetricFilter.ALL
+        injector.instanceOf[MetricsFilter] mustBe a[MetricsFilterImpl]
+        injector.instanceOf[Metrics] mustBe a[MetricsImpl]
+        injector.instanceOf[GraphiteReporting] mustBe a[EnabledGraphiteReporting]
+      }
+    }
+
+    def haveDisabledNonLegacyMetrics(configuration : Configuration): Unit = {
+      val injector = buildInjectorWithMetrics(configuration)
+
+      "create new bindings with reporting disabled" in {
         injector.instanceOf[MetricFilter] mustEqual MetricFilter.ALL
         injector.instanceOf[MetricsFilter] mustBe a[DisabledMetricsFilter]
         injector.instanceOf[Metrics] mustBe a[DisabledMetrics]

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModuleSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModuleSpec.scala
@@ -24,10 +24,6 @@ import play.api.inject.guice.GuiceApplicationBuilder
 
 class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAndAfterEach {
 
-  def app: GuiceApplicationBuilder =
-    new GuiceApplicationBuilder()
-      .bindings(new GraphiteMetricsModule)
-
   override def beforeEach(): Unit = {
     super.beforeEach()
     SharedMetricRegistries.clear()
@@ -35,21 +31,19 @@ class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAn
 
   ".bindings" when {
 
-    "`$env.metrics.graphite.legacy` is true" when {
+    "`$env.microservice.metrics.graphite.legacy` is true" when {
 
-      "`$env.metrics.enabled` is not set" must {
+      "`$env.microservice.metrics.enabled` is not set" must {
         behave like haveLegacyBindings(Configuration())
       }
 
       "`metrics.enabled` is set to true" must {
-        behave like haveLegacyBindings(Configuration("Test.metrics.enabled" -> "true"))
+        behave like haveLegacyBindings(Configuration("Test.microservice.metrics.enabled" -> "true"))
       }
 
       "`metrics.enabled` is set to false" must {
 
-        val injector = app.configure(
-          "Test.metrics.enabled" -> "false"
-        ).build().injector
+        val injector = buildInjectorWithMetrics(Configuration("Test.microservice.metrics.enabled" -> "false"))
 
         "create legacy bindings with reporting disabled" in {
           injector.instanceOf[MetricsFilter] mustBe a[DisabledMetricsFilter]
@@ -61,9 +55,9 @@ class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAn
     "`$env.metrics.graphite.legacy` is false" when {
 
       val graphiteConfiguration = Configuration(
-        "Test.metrics.graphite.legacy" -> "false",
-        "Test.metrics.graphite.host" -> "test",
-        "Test.metrics.graphite.port" -> "9999",
+        "Test.microservice.metrics.graphite.legacy" -> "false",
+        "Test.microservice.metrics.graphite.host" -> "test",
+        "Test.microservice.metrics.graphite.port" -> "9999",
         "appName" -> "test"
       )
 
@@ -72,11 +66,11 @@ class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAn
       }
 
       "`$env.metrics.enabled` is set to true" must {
-        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("Test.metrics.enabled" -> "true"))
+        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("Test.microservice.metrics.enabled" -> "true"))
       }
 
       "`$env.metrics.enabled` is set to false" must {
-        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("Test.metrics.enabled" -> "false"))
+        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("Test.microservice.metrics.enabled" -> "false"))
       }
 
     }
@@ -84,9 +78,9 @@ class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAn
     " environment specific configuration is not set but default configuration is provided " when {
 
       val graphiteConfiguration = Configuration(
-        "metrics.graphite.legacy" -> "false",
-        "metrics.graphite.host" -> "test",
-        "metrics.graphite.port" -> "9999",
+        "microservice.metrics.graphite.legacy" -> "false",
+        "microservice.metrics.graphite.host" -> "test",
+        "microservice.metrics.graphite.port" -> "9999",
         "appName" -> "test"
       )
 
@@ -95,21 +89,21 @@ class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAn
       }
 
       "`metrics.enabled` is set to true" must {
-        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("metrics.enabled" -> "true"))
+        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("microservice.metrics.enabled" -> "true"))
       }
 
       "`metrics.enabled` is set to false" must {
-        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("metrics.enabled" -> "false"))
+        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("microservice.metrics.enabled" -> "false"))
       }
 
     }
 
     " both environment configuration and default configuration specified" when {
       val graphiteConfiguration = Configuration(
-        "Test.metrics.graphite.legacy" -> "false",
-        "metrics.graphite.legacy" -> "true",
-        "Test.metrics.graphite.host" -> "test",
-        "Test.metrics.graphite.port" -> "9999",
+        "Test.microservice.metrics.graphite.legacy" -> "false",
+        "microservice.metrics.graphite.legacy" -> "true",
+        "Test.microservice.metrics.graphite.host" -> "test",
+        "Test.microservice.metrics.graphite.port" -> "9999",
         "appName" -> "test"
       )
 
@@ -118,11 +112,11 @@ class GraphiteMetricsModuleSpec extends WordSpec with MustMatchers with BeforeAn
       }
 
       "`metrics.enabled` is set to true" must {
-        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("Test.metrics.enabled" -> "true"))
+        behave like haveDefaultBindings(graphiteConfiguration ++ Configuration("Test.microservice.metrics.enabled" -> "true"))
       }
 
       "`metrics.enabled` is set to false" must {
-        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("Test.metrics.enabled" -> "false"))
+        behave like haveDisabledNonLegacyMetrics(graphiteConfiguration ++ Configuration("Test.microservice.metrics.enabled" -> "false"))
       }
     }
 

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteProviderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteProviderSpec.scala
@@ -19,43 +19,31 @@ package uk.gov.hmrc.play.graphite
 import com.typesafe.config.ConfigException
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.Configuration
-import play.api.inject.Injector
-import play.api.inject.guice.GuiceApplicationBuilder
 
 class GraphiteProviderSpec extends WordSpec with MustMatchers {
 
   "GraphiteProviderConfigSpec.fromConfig" must {
 
-    val configuration: Map[String, String] = Map(
-      "metrics.graphite.host" -> "localhost",
-      "metrics.graphite.port" -> "9999"
+    val metricsConfiguration: Map[String, Any] = Map(
+      "graphite.host" -> "localhost",
+      "graphite.port" -> "9999"
     )
 
     "return a valid `GraphiteProviderConfig`" in {
 
-      val injector: Injector = new GuiceApplicationBuilder()
-        .configure(configuration)
-        .build()
-        .injector
-
       val config: GraphiteProviderConfig =
-        GraphiteProviderConfig.fromConfig(injector.instanceOf[Configuration])
+        GraphiteProviderConfig.fromConfig(Configuration.from(metricsConfiguration))
 
       config.host mustEqual "localhost"
       config.port mustEqual 9999
     }
 
-    configuration.keys.foreach {
-      key =>
-        s"throw a configuration exception when config key: $key, is missing" in {
-
-          val injector = new GuiceApplicationBuilder()
-            .configure(configuration - key)
-            .build()
-            .injector
+    metricsConfiguration.keys.foreach {
+      missingKey =>
+        s"throw a configuration exception when config key: $missingKey, is missing" in {
 
           intercept[ConfigException.Missing] {
-            GraphiteProviderConfig.fromConfig(injector.instanceOf[Configuration])
+            GraphiteProviderConfig.fromConfig(Configuration.from(metricsConfiguration - missingKey))
           }
         }
     }


### PR DESCRIPTION
Properties are expected to be prefixed with "${env}.microservice.metrics" with fallback to "microservice.metrics"