### PR TITLE
Using play-config RunMode to determine run mode to handle prefixed configuration properties

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -47,7 +47,7 @@ private object AppDependencies {
 
   val compile = Seq(
     "com.typesafe.play" %% "play" % PlayVersion.current,
-    "uk.gov.hmrc" %% "play-config" % "4.3.0-1-g5f30c99",
+    "uk.gov.hmrc" %% "play-config" % "4.3.0-3-gc657af1",
     "com.codahale.metrics" % "metrics-graphite" % "3.0.2",
     "de.threedimensions" %% "metrics-play" % "2.5.13"
   )

--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -47,7 +47,7 @@ private object AppDependencies {
 
   val compile = Seq(
     "com.typesafe.play" %% "play" % PlayVersion.current,
-    "uk.gov.hmrc" %% "play-config" % "4.3.0-3-gc657af1",
+    "uk.gov.hmrc" %% "play-config" % "5.0.0",
     "com.codahale.metrics" % "metrics-graphite" % "3.0.2",
     "de.threedimensions" %% "metrics-play" % "2.5.13"
   )

--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -47,6 +47,7 @@ private object AppDependencies {
 
   val compile = Seq(
     "com.typesafe.play" %% "play" % PlayVersion.current,
+    "uk.gov.hmrc" %% "play-config" % "4.3.0-1-g5f30c99",
     "com.codahale.metrics" % "metrics-graphite" % "3.0.2",
     "de.threedimensions" %% "metrics-play" % "2.5.13"
   )

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModule.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModule.scala
@@ -21,43 +21,15 @@ import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
 import com.kenshoo.play.metrics._
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.play.config.ModeAwareConfiguration
-
+import uk.gov.hmrc.play.config.RunMode
 
 class GraphiteMetricsModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-
-    val modeAwareConfiguration = ModeAwareConfiguration(configuration, environment.mode)
-
-    if (modeAwareConfiguration.getBoolean("microservice.metrics.graphite.legacy").getOrElse(true)) {
-      legacy(modeAwareConfiguration)
-    } else {
-      newBindings(modeAwareConfiguration)
-    }
-  }
-
-  private def legacy(configuration: Configuration): Seq[Binding[_]] = {
-    if (kenshoMetricsEnabled(configuration)) {
-      Seq(
-        bind[MetricsFilter].to[MetricsFilterImpl].eagerly,
-        bind[Metrics].to[GraphiteMetricsImpl].eagerly
-      )
-    } else {
-      Seq(
-        bind[MetricsFilter].to[DisabledMetricsFilter].eagerly,
-        bind[Metrics].to[DisabledMetrics].eagerly
-      )
-    }
-  }
-
-  private def newBindings(configuration: Configuration): Seq[Binding[_]] = {
-
     val defaultBindings: Seq[Binding[_]] = Seq(
       // Note: `MetricFilter` rather than `MetricsFilter`
       bind[MetricFilter].toInstance(MetricFilter.ALL).eagerly
     )
-
 
     val kenshoBindings : Seq[Binding[_]] =
       if (kenshoMetricsEnabled(configuration)) {
@@ -70,28 +42,36 @@ class GraphiteMetricsModule extends Module {
           bind[Metrics].to[DisabledMetrics].eagerly)
       }
 
+    val graphiteConfiguration = extractGraphiteConfiguration(environment, configuration)
+
     val graphiteBindings: Seq[Binding[_]] =
-      if (kenshoMetricsEnabled(configuration) && graphitePublisherEnabled(configuration)) {
-          Seq(
-            bind[GraphiteProviderConfig].toInstance(GraphiteProviderConfig.fromConfig(configuration)),
-            bind[GraphiteReporterProviderConfig].toInstance(GraphiteReporterProviderConfig.fromConfig(configuration)),
-            bind[Graphite].toProvider[GraphiteProvider],
-            bind[GraphiteReporter].toProvider[GraphiteReporterProvider],
-            bind[GraphiteReporting].to[EnabledGraphiteReporting].eagerly
-          )
-        } else {
-          Seq(
-            bind[GraphiteReporting].to[DisabledGraphiteReporting].eagerly
-          )
-        }
+      if (kenshoMetricsEnabled(configuration) && graphitePublisherEnabled(graphiteConfiguration)) {
+        Seq(
+          bind[GraphiteProviderConfig].toInstance(GraphiteProviderConfig.fromConfig(graphiteConfiguration)),
+          bind[GraphiteReporterProviderConfig].toInstance(GraphiteReporterProviderConfig.fromConfig(configuration, graphiteConfiguration)),
+          bind[Graphite].toProvider[GraphiteProvider],
+          bind[GraphiteReporter].toProvider[GraphiteReporterProvider],
+          bind[GraphiteReporting].to[EnabledGraphiteReporting].eagerly
+        )
+      } else {
+        Seq(
+          bind[GraphiteReporting].to[DisabledGraphiteReporting].eagerly
+        )
+      }
 
     defaultBindings ++ graphiteBindings ++ kenshoBindings
   }
 
-  private def kenshoMetricsEnabled(configuration: Configuration) =
-    configuration.getBoolean("metrics.enabled").getOrElse(false)
+  private def kenshoMetricsEnabled(rootConfiguration: Configuration) =
+    rootConfiguration.getBoolean("metrics.enabled").getOrElse(false)
 
-  private def graphitePublisherEnabled(configuration: Configuration) =
-    configuration.getBoolean("microservice.metrics.graphite.enabled").getOrElse(false)
+  private def graphitePublisherEnabled(graphiteConfiguration: Configuration) =
+    graphiteConfiguration.getBoolean("enabled").getOrElse(false)
 
+  private def extractGraphiteConfiguration(environment: Environment, configuration: Configuration): Configuration = {
+    val env = RunMode(environment.mode, configuration).env
+    configuration.getConfig(s"$env.microservice.metrics.graphite")
+      .orElse(configuration.getConfig("microservice.metrics.graphite"))
+      .getOrElse(Configuration())
+  }
 }

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModule.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteMetricsModule.scala
@@ -21,19 +21,23 @@ import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
 import com.kenshoo.play.metrics._
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
+import uk.gov.hmrc.play.config.ModeAwareConfiguration
+
 
 class GraphiteMetricsModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
 
-    if (configuration.getBoolean("microservice.metrics.graphite.legacy").getOrElse(true)) {
-      legacy(environment, configuration)
+    val modeAwareConfiguration = ModeAwareConfiguration(configuration, environment.mode)
+
+    if (modeAwareConfiguration.getBoolean("microservice.metrics.graphite.legacy").getOrElse(true)) {
+      legacy(modeAwareConfiguration)
     } else {
-      newBindings(environment, configuration)
+      newBindings(modeAwareConfiguration)
     }
   }
 
-  private def legacy(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  private def legacy(configuration: Configuration): Seq[Binding[_]] = {
     if (kenshoMetricsEnabled(configuration)) {
       Seq(
         bind[MetricsFilter].to[MetricsFilterImpl].eagerly,
@@ -47,7 +51,7 @@ class GraphiteMetricsModule extends Module {
     }
   }
 
-  private def newBindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  private def newBindings(configuration: Configuration): Seq[Binding[_]] = {
 
     val defaultBindings: Seq[Binding[_]] = Seq(
       // Note: `MetricFilter` rather than `MetricsFilter`

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteProvider.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteProvider.scala
@@ -30,9 +30,9 @@ case class GraphiteProviderConfig(
 
 object GraphiteProviderConfig {
 
-  def fromConfig(config: Configuration): GraphiteProviderConfig = {
+  def fromConfig(graphiteConfiguration: Configuration): GraphiteProviderConfig = {
 
-    val graphite: Config  = config.underlying.getConfig("microservice.metrics.graphite")
+    val graphite: Config  = graphiteConfiguration.underlying
     val host: String      = graphite.getString("host")
     val port: Int         = graphite.getInt("port")
 

--- a/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteReporterProvider.scala
+++ b/src/main/scala/uk/gov/hmrc/play/graphite/GraphiteReporterProvider.scala
@@ -33,13 +33,13 @@ case class GraphiteReporterProviderConfig(
 
 object GraphiteReporterProviderConfig {
 
-  def fromConfig(config: Configuration): GraphiteReporterProviderConfig = {
+  def fromConfig(config: Configuration, graphiteConfiguration : Configuration): GraphiteReporterProviderConfig = {
 
     val appName: Option[String]       = config.getString("appName")
-    val rates: Option[TimeUnit]       = config.getString("microservice.metrics.graphite.rates").map(TimeUnit.valueOf)
-    val durations: Option[TimeUnit]   = config.getString("microservice.metrics.graphite.durations").map(TimeUnit.valueOf)
+    val rates: Option[TimeUnit]       = graphiteConfiguration.getString("rates").map(TimeUnit.valueOf)
+    val durations: Option[TimeUnit]   = graphiteConfiguration.getString("durations").map(TimeUnit.valueOf)
 
-    val prefix: String = config.getString("microservice.metrics.graphite.prefix")
+    val prefix: String = graphiteConfiguration.getString("prefix")
       .orElse(appName.map(name => s"tax.$name"))
       .getOrElse(throw new ConfigException.Generic("`metrics.graphite.prefix` in config or `appName` as parameter required"))
 

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteProviderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteProviderSpec.scala
@@ -27,8 +27,8 @@ class GraphiteProviderSpec extends WordSpec with MustMatchers {
   "GraphiteProviderConfigSpec.fromConfig" must {
 
     val configuration: Map[String, String] = Map(
-      "microservice.metrics.graphite.host" -> "localhost",
-      "microservice.metrics.graphite.port" -> "9999"
+      "host" -> "localhost",
+      "port" -> "9999"
     )
 
     "return a valid `GraphiteProviderConfig`" in {

--- a/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteReporterProviderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/graphite/GraphiteReporterProviderSpec.scala
@@ -29,16 +29,15 @@ class GraphiteReporterProviderSpec extends WordSpec with MustMatchers {
 
     "return a valid `GraphiteReporterProviderConfig` when given a prefix" in {
 
-      val injector = new GuiceApplicationBuilder()
-        .configure(
-          "appName" -> "testApp",
-          "microservice.metrics.graphite.prefix" -> "test"
-        )
-        .build()
-        .injector
+      val rootConfig = Configuration(
+        "appName" -> "testApp",
+        "microservice.metrics.graphite.prefix" -> "test"
+      )
+
+      val graphiteConfig = rootConfig.getConfig("microservice.metrics.graphite").get
 
       val config: GraphiteReporterProviderConfig =
-        GraphiteReporterProviderConfig.fromConfig(injector.instanceOf[Configuration])
+        GraphiteReporterProviderConfig.fromConfig(rootConfig, graphiteConfig)
 
       config.prefix mustEqual "test"
       config.rates mustBe None
@@ -47,17 +46,15 @@ class GraphiteReporterProviderSpec extends WordSpec with MustMatchers {
 
     "return a valid `GraphiteReporterProviderConfig` when given a prefix and optional config" in {
 
-      val injector = new GuiceApplicationBuilder()
-        .configure(
+      val rootConfig = Configuration(
           "microservice.metrics.graphite.prefix" -> "test",
           "microservice.metrics.graphite.durations" -> "SECONDS",
           "microservice.metrics.graphite.rates" -> "SECONDS"
         )
-        .build()
-        .injector
+      val graphiteConfig = rootConfig.getConfig("microservice.metrics.graphite").get
 
       val config: GraphiteReporterProviderConfig =
-        GraphiteReporterProviderConfig.fromConfig(injector.instanceOf[Configuration])
+        GraphiteReporterProviderConfig.fromConfig(rootConfig, graphiteConfig)
 
       config.prefix mustEqual "test"
       config.rates mustBe Some(TimeUnit.SECONDS)
@@ -66,13 +63,11 @@ class GraphiteReporterProviderSpec extends WordSpec with MustMatchers {
 
     "return a valid `GraphiteReporterProviderConfig` when given an appName" in {
 
-      val injector = new GuiceApplicationBuilder()
-        .configure("appName" -> "testApp")
-        .build()
-        .injector
+      val rootConfig = Configuration("appName" -> "testApp")
+      val graphiteConfig = Configuration()
 
       val config: GraphiteReporterProviderConfig =
-        GraphiteReporterProviderConfig.fromConfig(injector.instanceOf[Configuration])
+        GraphiteReporterProviderConfig.fromConfig(rootConfig, graphiteConfig)
 
       config.prefix mustEqual "tax.testApp"
       config.rates mustBe None
@@ -81,12 +76,8 @@ class GraphiteReporterProviderSpec extends WordSpec with MustMatchers {
 
     "throw a configuration exception when relevant keys are missing" in {
 
-      val injector = new GuiceApplicationBuilder()
-        .build()
-        .injector
-
       val exception = intercept[ConfigException.Generic] {
-        GraphiteReporterProviderConfig.fromConfig(injector.instanceOf[Configuration])
+        GraphiteReporterProviderConfig.fromConfig(Configuration(), Configuration())
       }
 
       exception.getMessage mustEqual "`metrics.graphite.prefix` in config or `appName` as parameter required"


### PR DESCRIPTION
Using play-config RunMode to determine run mode to handle prefixed configuration properties, removed support for legacy mode in guice mode (breaking change)